### PR TITLE
UI/league schedule tab setup

### DIFF
--- a/components/LeagueScheduleTable.tsx
+++ b/components/LeagueScheduleTable.tsx
@@ -1,236 +1,30 @@
+import {LeagueGames} from '@/pages/league/[id]';
 import {CheckIcon} from '@/public/icons';
 import {getFormattedDateTime} from '@/utils/helpers';
 import {Card, Table, Text} from '@nextui-org/react';
-import {FieldNumbers, Game} from '@prisma/client';
+import {FieldNumbers} from '@prisma/client';
 import React from 'react';
 
-type LeagueGames = {
-  homeTeam: string;
-  awayTeam: string;
-} & Omit<
-  Game,
-  | 'createdAt'
-  | 'createdById'
-  | 'modifiedAt'
-  | 'leagueId'
-  | 'homeTeamId'
-  | 'awayTeamId'
->;
+type LeagueScheduleTableProps = {
+  leagueGames: LeagueGames[] | undefined;
+};
 
 type TransformedLeagueGames = {
   gameDate: string;
   gameTime: string;
-  gameDateTime: Date;
+  gameDateTime: Date | string;
   games: Record<FieldNumbers, LeagueGames>;
 };
 
-export const LeagueScheduleTable = () => {
+export const LeagueScheduleTable = ({
+  leagueGames,
+}: LeagueScheduleTableProps) => {
   const [pageNumber, setPageNumber] = React.useState(1);
   const columns: {name: string; uid: FieldNumbers | 'gameTime'}[] = [
     {name: '', uid: 'gameTime'},
     {name: 'Pitch 1', uid: 'FIELD_1'},
     {name: 'Pitch 2', uid: 'FIELD_2'},
     {name: 'Pitch 3', uid: 'FIELD_3'},
-  ];
-  const games: LeagueGames[] = [
-    {
-      id: 1,
-      homeTeam: 'Atl United',
-      awayTeam: 'FC Cincinnati',
-      homeTeamScore: 4,
-      awayTeamScore: 0,
-      field: 'FIELD_1',
-      gameDateTime: new Date(1685296800000), // May 28, 2023, 2pm ET
-      gameResult: 'HOME_WIN',
-      isForfeit: null,
-    },
-    {
-      id: 2,
-      homeTeam: 'Tottenham',
-      awayTeam: 'Paris Saint German',
-      homeTeamScore: 0,
-      awayTeamScore: 1,
-      field: 'FIELD_2',
-      gameDateTime: new Date(1685296800000), // May 28, 2023, 2pm ET
-      gameResult: 'AWAY_WIN',
-      isForfeit: null,
-    },
-    {
-      id: 3,
-      homeTeam: 'Wrexham United',
-      awayTeam: 'Liverpool',
-      homeTeamScore: 2,
-      awayTeamScore: 1,
-      field: 'FIELD_3',
-      gameDateTime: new Date(1685296800000), // May 28, 2023, 2pm ET
-      gameResult: 'HOME_WIN',
-      isForfeit: null,
-    },
-    {
-      id: 4,
-      homeTeam: 'Napoli',
-      awayTeam: 'Ajax',
-      homeTeamScore: 1,
-      awayTeamScore: 1,
-      field: 'FIELD_1',
-      gameDateTime: new Date(1685300400000), // May 28, 2023, 3pm ET
-      gameResult: 'TIE',
-      isForfeit: null,
-    },
-    {
-      id: 5,
-      homeTeam: 'Porto',
-      awayTeam: 'Rangers',
-      homeTeamScore: 0,
-      awayTeamScore: 0,
-      field: 'FIELD_2',
-      gameDateTime: new Date(1685300400000), // May 28, 2023, 3pm ET
-      gameResult: 'TIE',
-      isForfeit: null,
-    },
-    {
-      id: 6,
-      homeTeam: 'Bayern',
-      awayTeam: 'Marseille',
-      homeTeamScore: 2,
-      awayTeamScore: 3,
-      field: 'FIELD_3',
-      gameDateTime: new Date(1685300400000), // May 28, 2023, 3pm ET
-      gameResult: 'AWAY_WIN',
-      isForfeit: null,
-    },
-    {
-      id: 7,
-      homeTeam: 'Arsenal',
-      awayTeam: 'Chelsea',
-      homeTeamScore: 2,
-      awayTeamScore: 5,
-      field: 'FIELD_1',
-      gameDateTime: new Date(1685901600000), // June 4, 2023, 2pm ET
-      gameResult: 'AWAY_WIN',
-      isForfeit: null,
-    },
-    {
-      id: 8,
-      homeTeam: 'Sevilla',
-      awayTeam: 'Real Madrid',
-      homeTeamScore: 0,
-      awayTeamScore: 0,
-      field: 'FIELD_2',
-      gameDateTime: new Date(1685901600000), // June 4, 2023, 2pm ET
-      gameResult: 'TIE',
-      isForfeit: null,
-    },
-    {
-      id: 9,
-      homeTeam: 'LA Galaxy',
-      awayTeam: 'DC United',
-      homeTeamScore: 2,
-      awayTeamScore: 0,
-      field: 'FIELD_3',
-      gameDateTime: new Date(1685901600000), // June 4, 2023, 2pm ET
-      gameResult: 'HOME_WIN',
-      isForfeit: null,
-    },
-    {
-      id: 10,
-      homeTeam: 'Crystal Palace',
-      awayTeam: 'Aston Villa',
-      homeTeamScore: 0,
-      awayTeamScore: 0,
-      field: 'FIELD_1',
-      gameDateTime: new Date(1685905200000), // June 4, 2023, 3pm ET
-      gameResult: null,
-      isForfeit: null,
-    },
-    {
-      id: 11,
-      homeTeam: 'West Ham',
-      awayTeam: 'Everton',
-      homeTeamScore: 0,
-      awayTeamScore: 0,
-      field: 'FIELD_2',
-      gameDateTime: new Date(1685905200000), // June 4, 2023, 3pm ET
-      gameResult: null,
-      isForfeit: null,
-    },
-    {
-      id: 12,
-      homeTeam: 'Leeds United',
-      awayTeam: 'Newcastle',
-      homeTeamScore: 0,
-      awayTeamScore: 0,
-      field: 'FIELD_3',
-      gameDateTime: new Date(1685905200000), // June 4, 2023, 3pm ET
-      gameResult: null,
-      isForfeit: null,
-    },
-    {
-      id: 13,
-      homeTeam: 'Barcelona',
-      awayTeam: 'Inter Milan',
-      homeTeamScore: 0,
-      awayTeamScore: 0,
-      field: 'FIELD_1',
-      gameDateTime: new Date(1686506400000), // June 11, 2023, 2pm ET
-      gameResult: null,
-      isForfeit: null,
-    },
-    {
-      id: 14,
-      homeTeam: 'Man City',
-      awayTeam: 'Man united',
-      homeTeamScore: 0,
-      awayTeamScore: 0,
-      field: 'FIELD_2',
-      gameDateTime: new Date(1686506400000), // June 11, 2023, 2pm ET
-      gameResult: null,
-      isForfeit: null,
-    },
-    {
-      id: 15,
-      homeTeam: 'FC Dallas',
-      awayTeam: 'Seattle Sounders',
-      homeTeamScore: 0,
-      awayTeamScore: 0,
-      field: 'FIELD_3',
-      gameDateTime: new Date(1686506400000), // June 11, 2023, 2pm ET
-      gameResult: null,
-      isForfeit: null,
-    },
-    {
-      id: 16,
-      homeTeam: 'Chicago FC',
-      awayTeam: 'Inter Miami',
-      homeTeamScore: 0,
-      awayTeamScore: 0,
-      field: 'FIELD_1',
-      gameDateTime: new Date(1686510000000), // June 11, 2023, 3pm ET
-      gameResult: null,
-      isForfeit: null,
-    },
-    {
-      id: 17,
-      homeTeam: 'Toronto FC',
-      awayTeam: 'New York FC',
-      homeTeamScore: 0,
-      awayTeamScore: 0,
-      field: 'FIELD_2',
-      gameDateTime: new Date(1686510000000), // June 11, 2023, 3pm ET
-      gameResult: null,
-      isForfeit: null,
-    },
-    {
-      id: 18,
-      homeTeam: 'NY Redbulls',
-      awayTeam: 'Nashville',
-      homeTeamScore: 0,
-      awayTeamScore: 0,
-      field: 'FIELD_3',
-      gameDateTime: new Date(1686510000000), // June 11, 2023, 3pm ET
-      gameResult: null,
-      isForfeit: null,
-    },
   ];
 
   const transformLeagueData = (games: LeagueGames[]) => {
@@ -302,7 +96,7 @@ export const LeagueScheduleTable = () => {
               css={{fontFamily: '$mono'}}
               size={'$lg'}
               weight={cellValue.gameResult === 'HOME_WIN' ? 'bold' : 'normal'}>
-              {cellValue.homeTeam} - {cellValue.homeTeamScore}{' '}
+              {cellValue.homeTeam.name} - {cellValue.homeTeamScore}{' '}
               {cellValue.gameResult === 'HOME_WIN' && (
                 <CheckIcon size={30} fill={'green'} />
               )}
@@ -312,7 +106,7 @@ export const LeagueScheduleTable = () => {
               css={{fontFamily: '$mono'}}
               size={'$lg'}
               weight={cellValue.gameResult === 'AWAY_WIN' ? 'bold' : 'normal'}>
-              {cellValue.awayTeam} - {cellValue.awayTeamScore}{' '}
+              {cellValue.awayTeam.name} - {cellValue.awayTeamScore}{' '}
               {cellValue.gameResult === 'AWAY_WIN' && (
                 <CheckIcon size={30} fill={'green'} />
               )}
@@ -329,7 +123,11 @@ export const LeagueScheduleTable = () => {
         {/* Display Game dates as header */}
         {
           Array.from(
-            new Set(transformLeagueData(games).map(({gameDate}) => gameDate)),
+            new Set(
+              transformLeagueData(leagueGames as LeagueGames[]).map(
+                ({gameDate}) => gameDate,
+              ),
+            ),
           )[pageNumber - 1]
         }
       </Text>
@@ -346,7 +144,7 @@ export const LeagueScheduleTable = () => {
             </Table.Column>
           )}
         </Table.Header>
-        <Table.Body items={transformLeagueData(games)}>
+        <Table.Body items={transformLeagueData(leagueGames as LeagueGames[])}>
           {(item: TransformedLeagueGames) => (
             <Table.Row key={item.gameDate + item.gameTime}>
               {columnKey => (

--- a/components/LeagueScheduleTable.tsx
+++ b/components/LeagueScheduleTable.tsx
@@ -1,0 +1,368 @@
+import {CheckIcon} from '@/public/icons';
+import {getFormattedDateTime} from '@/utils/helpers';
+import {Card, Table, Text} from '@nextui-org/react';
+import {FieldNumbers, Game} from '@prisma/client';
+import React from 'react';
+
+type LeagueGames = {
+  homeTeam: string;
+  awayTeam: string;
+} & Omit<
+  Game,
+  | 'createdAt'
+  | 'createdById'
+  | 'modifiedAt'
+  | 'leagueId'
+  | 'homeTeamId'
+  | 'awayTeamId'
+>;
+
+type TransformedLeagueGames = {
+  gameDate: string;
+  gameTime: string;
+  gameDateTime: Date;
+  games: Record<FieldNumbers, LeagueGames>;
+};
+
+export const LeagueScheduleTable = () => {
+  const [pageNumber, setPageNumber] = React.useState(1);
+  const columns: {name: string; uid: FieldNumbers | 'gameTime'}[] = [
+    {name: '', uid: 'gameTime'},
+    {name: 'Pitch 1', uid: 'FIELD_1'},
+    {name: 'Pitch 2', uid: 'FIELD_2'},
+    {name: 'Pitch 3', uid: 'FIELD_3'},
+  ];
+  const games: LeagueGames[] = [
+    {
+      id: 1,
+      homeTeam: 'Atl United',
+      awayTeam: 'FC Cincinnati',
+      homeTeamScore: 4,
+      awayTeamScore: 0,
+      field: 'FIELD_1',
+      gameDateTime: new Date(1685296800000), // May 28, 2023, 2pm ET
+      gameResult: 'HOME_WIN',
+      isForfeit: null,
+    },
+    {
+      id: 2,
+      homeTeam: 'Tottenham',
+      awayTeam: 'Paris Saint German',
+      homeTeamScore: 0,
+      awayTeamScore: 1,
+      field: 'FIELD_2',
+      gameDateTime: new Date(1685296800000), // May 28, 2023, 2pm ET
+      gameResult: 'AWAY_WIN',
+      isForfeit: null,
+    },
+    {
+      id: 3,
+      homeTeam: 'Wrexham United',
+      awayTeam: 'Liverpool',
+      homeTeamScore: 2,
+      awayTeamScore: 1,
+      field: 'FIELD_3',
+      gameDateTime: new Date(1685296800000), // May 28, 2023, 2pm ET
+      gameResult: 'HOME_WIN',
+      isForfeit: null,
+    },
+    {
+      id: 4,
+      homeTeam: 'Napoli',
+      awayTeam: 'Ajax',
+      homeTeamScore: 1,
+      awayTeamScore: 1,
+      field: 'FIELD_1',
+      gameDateTime: new Date(1685300400000), // May 28, 2023, 3pm ET
+      gameResult: 'TIE',
+      isForfeit: null,
+    },
+    {
+      id: 5,
+      homeTeam: 'Porto',
+      awayTeam: 'Rangers',
+      homeTeamScore: 0,
+      awayTeamScore: 0,
+      field: 'FIELD_2',
+      gameDateTime: new Date(1685300400000), // May 28, 2023, 3pm ET
+      gameResult: 'TIE',
+      isForfeit: null,
+    },
+    {
+      id: 6,
+      homeTeam: 'Bayern',
+      awayTeam: 'Marseille',
+      homeTeamScore: 2,
+      awayTeamScore: 3,
+      field: 'FIELD_3',
+      gameDateTime: new Date(1685300400000), // May 28, 2023, 3pm ET
+      gameResult: 'AWAY_WIN',
+      isForfeit: null,
+    },
+    {
+      id: 7,
+      homeTeam: 'Arsenal',
+      awayTeam: 'Chelsea',
+      homeTeamScore: 2,
+      awayTeamScore: 5,
+      field: 'FIELD_1',
+      gameDateTime: new Date(1685901600000), // June 4, 2023, 2pm ET
+      gameResult: 'AWAY_WIN',
+      isForfeit: null,
+    },
+    {
+      id: 8,
+      homeTeam: 'Sevilla',
+      awayTeam: 'Real Madrid',
+      homeTeamScore: 0,
+      awayTeamScore: 0,
+      field: 'FIELD_2',
+      gameDateTime: new Date(1685901600000), // June 4, 2023, 2pm ET
+      gameResult: 'TIE',
+      isForfeit: null,
+    },
+    {
+      id: 9,
+      homeTeam: 'LA Galaxy',
+      awayTeam: 'DC United',
+      homeTeamScore: 2,
+      awayTeamScore: 0,
+      field: 'FIELD_3',
+      gameDateTime: new Date(1685901600000), // June 4, 2023, 2pm ET
+      gameResult: 'HOME_WIN',
+      isForfeit: null,
+    },
+    {
+      id: 10,
+      homeTeam: 'Crystal Palace',
+      awayTeam: 'Aston Villa',
+      homeTeamScore: 0,
+      awayTeamScore: 0,
+      field: 'FIELD_1',
+      gameDateTime: new Date(1685905200000), // June 4, 2023, 3pm ET
+      gameResult: null,
+      isForfeit: null,
+    },
+    {
+      id: 11,
+      homeTeam: 'West Ham',
+      awayTeam: 'Everton',
+      homeTeamScore: 0,
+      awayTeamScore: 0,
+      field: 'FIELD_2',
+      gameDateTime: new Date(1685905200000), // June 4, 2023, 3pm ET
+      gameResult: null,
+      isForfeit: null,
+    },
+    {
+      id: 12,
+      homeTeam: 'Leeds United',
+      awayTeam: 'Newcastle',
+      homeTeamScore: 0,
+      awayTeamScore: 0,
+      field: 'FIELD_3',
+      gameDateTime: new Date(1685905200000), // June 4, 2023, 3pm ET
+      gameResult: null,
+      isForfeit: null,
+    },
+    {
+      id: 13,
+      homeTeam: 'Barcelona',
+      awayTeam: 'Inter Milan',
+      homeTeamScore: 0,
+      awayTeamScore: 0,
+      field: 'FIELD_1',
+      gameDateTime: new Date(1686506400000), // June 11, 2023, 2pm ET
+      gameResult: null,
+      isForfeit: null,
+    },
+    {
+      id: 14,
+      homeTeam: 'Man City',
+      awayTeam: 'Man united',
+      homeTeamScore: 0,
+      awayTeamScore: 0,
+      field: 'FIELD_2',
+      gameDateTime: new Date(1686506400000), // June 11, 2023, 2pm ET
+      gameResult: null,
+      isForfeit: null,
+    },
+    {
+      id: 15,
+      homeTeam: 'FC Dallas',
+      awayTeam: 'Seattle Sounders',
+      homeTeamScore: 0,
+      awayTeamScore: 0,
+      field: 'FIELD_3',
+      gameDateTime: new Date(1686506400000), // June 11, 2023, 2pm ET
+      gameResult: null,
+      isForfeit: null,
+    },
+    {
+      id: 16,
+      homeTeam: 'Chicago FC',
+      awayTeam: 'Inter Miami',
+      homeTeamScore: 0,
+      awayTeamScore: 0,
+      field: 'FIELD_1',
+      gameDateTime: new Date(1686510000000), // June 11, 2023, 3pm ET
+      gameResult: null,
+      isForfeit: null,
+    },
+    {
+      id: 17,
+      homeTeam: 'Toronto FC',
+      awayTeam: 'New York FC',
+      homeTeamScore: 0,
+      awayTeamScore: 0,
+      field: 'FIELD_2',
+      gameDateTime: new Date(1686510000000), // June 11, 2023, 3pm ET
+      gameResult: null,
+      isForfeit: null,
+    },
+    {
+      id: 18,
+      homeTeam: 'NY Redbulls',
+      awayTeam: 'Nashville',
+      homeTeamScore: 0,
+      awayTeamScore: 0,
+      field: 'FIELD_3',
+      gameDateTime: new Date(1686510000000), // June 11, 2023, 3pm ET
+      gameResult: null,
+      isForfeit: null,
+    },
+  ];
+
+  const transformLeagueData = (games: LeagueGames[]) => {
+    const newGames = games.reduce(
+      (acc: TransformedLeagueGames[], curr: LeagueGames, idx: number) => {
+        const matchedIndex = acc.findIndex(
+          (transformedGame: TransformedLeagueGames) => {
+            const currDateTime = curr.gameDateTime || new Date();
+            return (
+              getFormattedDateTime(transformedGame.gameDateTime).date ===
+                getFormattedDateTime(currDateTime).date &&
+              getFormattedDateTime(transformedGame.gameDateTime).time ===
+                getFormattedDateTime(currDateTime).time
+            );
+          },
+        );
+
+        if (matchedIndex !== -1) {
+          const {gameDateTime, games} = acc[matchedIndex];
+          const gameRow: TransformedLeagueGames = {
+            gameDate: getFormattedDateTime(gameDateTime).date,
+            gameTime: getFormattedDateTime(gameDateTime).time,
+            gameDateTime,
+            games: {
+              ...games,
+              [String(curr.field)]: curr,
+            },
+          };
+
+          acc.splice(matchedIndex, 1, gameRow);
+        } else {
+          const currGameDateTime = curr.gameDateTime || new Date();
+          const gameRow: TransformedLeagueGames = {
+            gameDate: getFormattedDateTime(currGameDateTime).date,
+            gameTime: getFormattedDateTime(currGameDateTime).time,
+            gameDateTime: currGameDateTime,
+            games: {
+              [String(curr.field)]: curr,
+            } as any,
+          };
+
+          acc.push(gameRow);
+        }
+
+        return acc;
+      },
+      [],
+    );
+
+    return newGames;
+  };
+
+  const renderCell = (item: TransformedLeagueGames, columnKey: React.Key) => {
+    if (columnKey === 'gameTime') {
+      return (
+        <div>
+          <Text weight={'bold'} size={'$xl'} css={{textAlign: 'center'}}>
+            {item.gameTime}
+          </Text>
+        </div>
+      );
+    } else {
+      const cellValue = item.games[columnKey as FieldNumbers];
+
+      return (
+        <Card>
+          <Card.Body css={{paddingLeft: '$xl'}}>
+            <Text
+              css={{fontFamily: '$mono'}}
+              size={'$lg'}
+              weight={cellValue.gameResult === 'HOME_WIN' ? 'bold' : 'normal'}>
+              {cellValue.homeTeam} - {cellValue.homeTeamScore}{' '}
+              {cellValue.gameResult === 'HOME_WIN' && (
+                <CheckIcon size={30} fill={'green'} />
+              )}
+            </Text>
+            <Text css={{fontFamily: '$mono'}}>vs</Text>
+            <Text
+              css={{fontFamily: '$mono'}}
+              size={'$lg'}
+              weight={cellValue.gameResult === 'AWAY_WIN' ? 'bold' : 'normal'}>
+              {cellValue.awayTeam} - {cellValue.awayTeamScore}{' '}
+              {cellValue.gameResult === 'AWAY_WIN' && (
+                <CheckIcon size={30} fill={'green'} />
+              )}
+            </Text>
+          </Card.Body>
+        </Card>
+      );
+    }
+  };
+
+  return (
+    <>
+      <Text h3 css={{paddingLeft: '$lg', fontFamily: '$mono'}}>
+        {/* Display Game dates as header */}
+        {
+          Array.from(
+            new Set(transformLeagueData(games).map(({gameDate}) => gameDate)),
+          )[pageNumber - 1]
+        }
+      </Text>
+      <Table
+        aria-label="Example table with static content"
+        css={{
+          height: 'auto',
+          minWidth: '100%',
+        }}>
+        <Table.Header columns={columns}>
+          {column => (
+            <Table.Column key={column.uid} align="center">
+              {column.name}
+            </Table.Column>
+          )}
+        </Table.Header>
+        <Table.Body items={transformLeagueData(games)}>
+          {(item: TransformedLeagueGames) => (
+            <Table.Row key={item.gameDate + item.gameTime}>
+              {columnKey => (
+                <Table.Cell>{renderCell(item, columnKey)}</Table.Cell>
+              )}
+            </Table.Row>
+          )}
+        </Table.Body>
+        <Table.Pagination
+          shadow
+          noMargin
+          align="center"
+          rowsPerPage={2}
+          onPageChange={page => setPageNumber(page)}
+        />
+      </Table>
+    </>
+  );
+};

--- a/data/sampleGames.ts
+++ b/data/sampleGames.ts
@@ -1,0 +1,286 @@
+'use strict';
+
+import {FieldNumbers, GameResult, Prisma, PrismaClient} from '@prisma/client';
+
+/**
+ * NOTE: the foreign key IDs may need to be changed for your local Prisma instance
+ */
+const gameData = [
+  {
+    // id: 1,
+    homeTeamId: 26,
+    awayTeamId: 27,
+    homeTeamScore: 4,
+    awayTeamScore: 0,
+    field: 'FIELD_1',
+    gameDateTime: new Date(1685296800000), // May 28, 2023, 2pm ET
+    gameResult: 'AWAY_WIN',
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 2,
+    homeTeamId: 28,
+    awayTeamId: 29,
+    homeTeamScore: 0,
+    awayTeamScore: 1,
+    field: 'FIELD_2',
+    gameDateTime: new Date(1685296800000), // May 28, 2023, 2pm ET
+    gameResult: 'AWAY_WIN',
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 3,
+    homeTeamId: 30,
+    awayTeamId: 31,
+    homeTeamScore: 2,
+    awayTeamScore: 1,
+    field: 'FIELD_3',
+    gameDateTime: new Date(1685296800000), // May 28, 2023, 2pm ET
+    gameResult: 'HOME_WIN',
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 4,
+    homeTeamId: 32,
+    awayTeamId: 33,
+    homeTeamScore: 1,
+    awayTeamScore: 1,
+    field: 'FIELD_1',
+    gameDateTime: new Date(1685300400000), // May 28, 2023, 3pm ET
+    gameResult: 'TIE',
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 5,
+    homeTeamId: 34,
+    awayTeamId: 26,
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    field: 'FIELD_2',
+    gameDateTime: new Date(1685300400000), // May 28, 2023, 3pm ET
+    gameResult: 'TIE',
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 6,
+    homeTeamId: 27,
+    awayTeamId: 29,
+    homeTeamScore: 2,
+    awayTeamScore: 3,
+    field: 'FIELD_3',
+    gameDateTime: new Date(1685300400000), // May 28, 2023, 3pm ET
+    gameResult: 'AWAY_WIN',
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 7,
+    homeTeamId: 28,
+    awayTeamId: 30,
+    homeTeamScore: 2,
+    awayTeamScore: 5,
+    field: 'FIELD_1',
+    gameDateTime: new Date(1685901600000), // June 4, 2023, 2pm ET
+    gameResult: 'AWAY_WIN',
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 8,
+    homeTeamId: 31,
+    awayTeamId: 33,
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    field: 'FIELD_2',
+    gameDateTime: new Date(1685901600000), // June 4, 2023, 2pm ET
+    gameResult: 'TIE',
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 9,
+    homeTeamId: 32,
+    awayTeamId: 34,
+    homeTeamScore: 2,
+    awayTeamScore: 0,
+    field: 'FIELD_3',
+    gameDateTime: new Date(1685901600000), // June 4, 2023, 2pm ET
+    gameResult: 'HOME_WIN',
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 10,
+    homeTeamId: 26,
+    awayTeamId: 29,
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    field: 'FIELD_1',
+    gameDateTime: new Date(1685905200000), // June 4, 2023, 3pm ET
+    gameResult: null,
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 11,
+    homeTeamId: 27,
+    awayTeamId: 30,
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    field: 'FIELD_2',
+    gameDateTime: new Date(1685905200000), // June 4, 2023, 3pm ET
+    gameResult: null,
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 12,
+    homeTeamId: 28,
+    awayTeamId: 31,
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    field: 'FIELD_3',
+    gameDateTime: new Date(1685905200000), // June 4, 2023, 3pm ET
+    gameResult: null,
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 13,
+    homeTeamId: 32,
+    awayTeamId: 26,
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    field: 'FIELD_1',
+    gameDateTime: new Date(1686506400000), // June 11, 2023, 2pm ET
+    gameResult: null,
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 14,
+    homeTeamId: 33,
+    awayTeamId: 27,
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    field: 'FIELD_2',
+    gameDateTime: new Date(1686506400000), // June 11, 2023, 2pm ET
+    gameResult: null,
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 15,
+    homeTeamId: 34,
+    awayTeamId: 28,
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    field: 'FIELD_3',
+    gameDateTime: new Date(1686506400000), // June 11, 2023, 2pm ET
+    gameResult: null,
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 16,
+    homeTeamId: 26,
+    awayTeamId: 30,
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    field: 'FIELD_1',
+    gameDateTime: new Date(1686510000000), // June 11, 2023, 3pm ET
+    gameResult: null,
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 17,
+    homeTeamId: 27,
+    awayTeamId: 31,
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    field: 'FIELD_2',
+    gameDateTime: new Date(1686510000000), // June 11, 2023, 3pm ET
+    gameResult: null,
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+  {
+    // id: 18,
+    homeTeamId: 28,
+    awayTeamId: 32,
+    homeTeamScore: 0,
+    awayTeamScore: 0,
+    field: 'FIELD_3',
+    gameDateTime: new Date(1686510000000), // June 11, 2023, 3pm ET
+    gameResult: null,
+    isForfeit: null,
+    leagueId: 1,
+    createdById: 72,
+  },
+];
+
+/**
+ * NOTE: using prisma.createMany gave me a foreignKey error, so using map + prisma.create instead.
+ */
+export const gameDataFactory = (
+  prisma: PrismaClient<
+    Prisma.PrismaClientOptions,
+    never,
+    Prisma.RejectOnNotFound | Prisma.RejectPerOperation | undefined
+  >,
+) =>
+  gameData.map(_ => {
+    return prisma.game.create({
+      data: {
+        league: {
+          connect: {
+            id: _.leagueId,
+          },
+        },
+        field: _.field as FieldNumbers,
+        homeTeam: {
+          connect: {
+            id: _.homeTeamId,
+          },
+        },
+        awayTeam: {
+          connect: {
+            id: _.awayTeamId,
+          },
+        },
+        homeTeamScore: _.homeTeamScore,
+        awayTeamScore: _.awayTeamScore,
+        gameDateTime: _.gameDateTime,
+        gameResult: _.gameResult as GameResult,
+        isForfeit: _.isForfeit,
+        createdBy: {
+          connect: {
+            id: _.createdById,
+          },
+        },
+      },
+    });
+  });

--- a/data/sampleTeams.ts
+++ b/data/sampleTeams.ts
@@ -1,0 +1,191 @@
+'use strict';
+
+import {Division, Prisma, PrismaClient, TeamFeeStatus} from '@prisma/client';
+
+/**
+ * NOTE: the foreign key IDs may need to be changed for your local Prisma instance
+ */
+const teamData = [
+  {
+    // id: 1,
+    leagueId: 1,
+    name: 'Atlanta United',
+    captainId: 72,
+    feeStatus: 'PAID',
+    division: 'D1',
+    wins: 6,
+    losses: 4,
+    draws: 5,
+    createdById: 72,
+  },
+  {
+    // id: 2,
+    leagueId: 1,
+    name: 'Austin FC',
+    captainId: 84,
+    feeStatus: 'PAID',
+    division: 'D1',
+    wins: 4,
+    losses: 6,
+    draws: 4,
+    createdById: 72,
+  },
+  {
+    // id: 3,
+    leagueId: 1,
+    name: 'Dallas FC',
+    captainId: 85,
+    feeStatus: 'PAID',
+    division: 'D1',
+    wins: 4,
+    losses: 6,
+    draws: 4,
+    createdById: 72,
+  },
+  {
+    // id: 4,
+    leagueId: 1,
+    name: 'Manchester United',
+    captainId: 86,
+    feeStatus: 'PAID',
+    division: 'D1',
+    wins: 4,
+    losses: 6,
+    draws: 4,
+    createdById: 72,
+  },
+  {
+    // id: 5,
+    leagueId: 1,
+    name: 'Manchester City',
+    captainId: 76,
+    feeStatus: 'PAID',
+    division: 'D1',
+    wins: 4,
+    losses: 6,
+    draws: 4,
+    createdById: 72,
+  },
+  {
+    // id: 6,
+    leagueId: 1,
+    name: 'Inter Milan',
+    captainId: 77,
+    feeStatus: 'PAID',
+    division: 'D1',
+    wins: 4,
+    losses: 6,
+    draws: 4,
+    createdById: 72,
+  },
+  {
+    // id: 7,
+    leagueId: 1,
+    name: 'Barcelona',
+    captainId: 78,
+    feeStatus: 'PAID',
+    division: 'D1',
+    wins: 4,
+    losses: 6,
+    draws: 4,
+    createdById: 72,
+  },
+  {
+    // id: 8,
+    leagueId: 1,
+    name: 'Real Madrid',
+    captainId: 79,
+    feeStatus: 'PAID',
+    division: 'D1',
+    wins: 4,
+    losses: 6,
+    draws: 4,
+    createdById: 72,
+  },
+  {
+    // id: 9,
+    leagueId: 1,
+    name: 'Inter Miami',
+    captainId: 80,
+    feeStatus: 'PAID',
+    division: 'D1',
+    wins: 4,
+    losses: 6,
+    draws: 4,
+    createdById: 72,
+  },
+  {
+    // id: 10,
+    leagueId: 1,
+    name: 'Seattle Sounders',
+    captainId: 81,
+    feeStatus: 'PAID',
+    division: 'D1',
+    wins: 4,
+    losses: 6,
+    draws: 4,
+    createdById: 72,
+  },
+  {
+    // id: 11,
+    leagueId: 1,
+    name: 'Cincinnati FC',
+    captainId: 82,
+    feeStatus: 'PAID',
+    division: 'D1',
+    wins: 4,
+    losses: 6,
+    draws: 4,
+    createdById: 72,
+  },
+  {
+    // id: 12,
+    leagueId: 1,
+    name: 'New York Redbulls',
+    captainId: 83,
+    feeStatus: 'PAID',
+    division: 'D1',
+    wins: 4,
+    losses: 6,
+    draws: 4,
+    createdById: 72,
+  },
+];
+
+/**
+ * NOTE: using prisma.createMany gave me a foreignKey error, so using map + prisma.create instead.
+ */
+export const teamDataFactory = (
+  prisma: PrismaClient<
+    Prisma.PrismaClientOptions,
+    never,
+    Prisma.RejectOnNotFound | Prisma.RejectPerOperation | undefined
+  >,
+) =>
+  teamData.map(_ => {
+    return prisma.team.create({
+      data: {
+        league: {
+          connect: {
+            id: _.leagueId,
+          },
+        },
+        name: _.name,
+        captain: {
+          connect: {
+            id: _.captainId,
+          },
+        },
+        feeStatus: _.feeStatus as TeamFeeStatus,
+        division: _.division as Division,
+        wins: _.wins,
+        losses: _.losses,
+        draws: _.draws,
+        createdBy: {
+          connect: {
+            id: _.createdById,
+          },
+        },
+      },
+    });
+  });

--- a/graphql/queries/leagues.ts
+++ b/graphql/queries/leagues.ts
@@ -29,4 +29,36 @@ export const leagueResolvers = {
       return leagues;
     },
   },
+  League: {
+    teams: async (parent: any) => {
+      const leagueTeams = await prisma.team.findMany({
+        where: {leagueId: parent.id},
+      });
+
+      return leagueTeams;
+    },
+    games: async (parent: any) => {
+      const leagueGames = await prisma.game.findMany({
+        where: {leagueId: parent.id},
+      });
+
+      return leagueGames;
+    },
+  },
+  Game: {
+    homeTeam: async (parent: any) => {
+      const __homeTeam = await prisma.team.findFirst({
+        where: {id: parent.homeTeamId},
+      });
+
+      return __homeTeam;
+    },
+    awayTeam: async (parent: any) => {
+      const __awayTeam = await prisma.team.findFirst({
+        where: {id: parent.awayTeamId},
+      });
+
+      return __awayTeam;
+    },
+  },
 };

--- a/graphql/queries/teams.ts
+++ b/graphql/queries/teams.ts
@@ -12,21 +12,16 @@ export const teamResolvers = {
     getAllTeams: async () => {
       const teams: any = await prisma.team.findMany();
 
-      console.log({teams});
-
       return teams;
     },
   },
   Mutation: {
     createTeam: async (parent: any, {input}: any, context: any) => {
-      console.log('CREATING TEAM...');
       const user: User | null = (await context).user;
 
       if (!user) {
         throw new Error('You need to be logged in to create a team');
       }
-
-      console.log('FOUND USER...', {user});
 
       const {captainId, name} = input;
       const data: Prisma.TeamCreateInput = {
@@ -37,8 +32,6 @@ export const teamResolvers = {
         division: 'D2',
         createdBy: {connect: {id: captainId}},
       };
-
-      console.log('TEAM DATA ---', {data});
 
       return prisma.team.create({
         data,

--- a/graphql/utils/helpers.ts
+++ b/graphql/utils/helpers.ts
@@ -1,8 +1,0 @@
-'use strict';
-
-export const baseUser = `
-  firstName: String
-  lastName: String
-  gender: UserGender
-  status: UserAccountStatus
-`;

--- a/pages/league/[id].tsx
+++ b/pages/league/[id].tsx
@@ -5,6 +5,7 @@ import {useRouter} from 'next/router';
 import React from 'react';
 import {format} from 'date-fns';
 import {Tab, TabList, TabPanel, Tabs} from 'react-tabs';
+import {LeagueScheduleTable} from '@/components/LeagueScheduleTable';
 
 const GetLeagueDetailsQuery = gql`
   query getLeagueDetailsQuery($leagueId: Int!) {
@@ -25,6 +26,7 @@ const GetLeagueDetailsQuery = gql`
       leagueType
       status
       signupDeadline
+      modifiedAt
     }
   }
 `;

--- a/pages/league/[id].tsx
+++ b/pages/league/[id].tsx
@@ -122,7 +122,7 @@ const LeagueDetailPage = () => {
             <Text>Description: {league.description}</Text>
           </TabPanel>
           <TabPanel>
-            <Text>TBD</Text>
+            <LeagueScheduleTable />
           </TabPanel>
           <TabPanel>
             <Text>TBD</Text>

--- a/pages/league/[id].tsx
+++ b/pages/league/[id].tsx
@@ -16,11 +16,22 @@ const GetLeagueDetailsQuery = gql`
       startDate
       endDate
       teams {
-        id
+        name
       }
       teamsMax
       games {
         id
+        homeTeam {
+          name
+        }
+        awayTeam {
+          name
+        }
+        homeTeamScore
+        awayTeamScore
+        field
+        gameDateTime
+        gameResult
       }
       location
       leagueType

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,6 @@
-import {PrismaClient, Prisma} from '@prisma/client';
+import {gameDataFactory} from '@/data/sampleGames';
+import {teamDataFactory} from '@/data/sampleTeams';
+import {PrismaClient} from '@prisma/client';
 
 const prisma = new PrismaClient();
 
@@ -416,7 +418,7 @@ async function main() {
         startDate: new Date(2023, 1, 1, 0, 0, 1),
         endDate: new Date(2023, 2, 24, 23, 59, 59),
         status: 'INACTIVE',
-        createdById: 1,
+        createdById: 72,
       },
       {
         id: 2,
@@ -426,55 +428,13 @@ async function main() {
         startDate: new Date(2023, 2, 25, 0, 0, 1),
         endDate: new Date(2023, 10, 21, 23, 59, 59),
         status: 'ACTIVE',
-        createdById: 1,
+        createdById: 72,
       },
     ],
   });
 
-  // Team
-  await prisma.team.createMany({
-    data: [
-      {
-        id: 1,
-        leagueId: 2,
-        name: 'Atlanta United',
-        captainId: 4,
-        feeStatus: 'PAID',
-        division: 'D1',
-        wins: 6,
-        losses: 4,
-        draws: 5,
-        createdById: 1,
-      },
-      {
-        id: 2,
-        leagueId: 2,
-        name: 'Austin FC',
-        captainId: 27,
-        feeStatus: 'PAID',
-        division: 'D1',
-        wins: 4,
-        losses: 6,
-        draws: 4,
-        createdById: 1,
-      },
-    ],
-  });
-
-  // Game
-  await prisma.game.create({
-    data: {
-      id: 1,
-      leagueId: 2,
-      homeTeamId: 1,
-      awayTeamId: 2,
-      homeTeamScore: 2,
-      awayTeamScore: 1,
-      gameResult: 'HOME_WIN',
-      isForfeit: false,
-      createdById: 1,
-    },
-  });
+  // Create game and team sample data
+  Promise.all([...gameDataFactory(prisma), ...teamDataFactory(prisma)]);
 }
 
 main()

--- a/public/icons.tsx
+++ b/public/icons.tsx
@@ -1,0 +1,30 @@
+export const CheckIcon = ({
+  fill = 'currentColor',
+  size,
+  height,
+  width,
+  ...props
+}: {
+  fill?: string;
+  size?: number;
+  height?: number;
+  width?: number;
+}) => {
+  return (
+    <svg
+      width={size || width || 18}
+      height={size || height || 18}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}>
+      <path
+        d="M7.75 11.9999L10.58 14.8299L16.25 9.16992"
+        stroke={fill}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -2,7 +2,9 @@
 
 import {format} from 'date-fns';
 
-export const getFormattedDateTime = (dateTime: Date) => {
+export const getFormattedDateTime = (date: Date | string) => {
+  const dateTime = typeof date === 'string' ? new Date(Number(date)) : date;
+
   return {
     date: format(dateTime, 'EEEE, LLL do'),
     time: format(dateTime, 'h:ss aaa'),

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,0 +1,10 @@
+'use strict';
+
+import {format} from 'date-fns';
+
+export const getFormattedDateTime = (dateTime: Date) => {
+  return {
+    date: format(dateTime, 'EEEE, LLL do'),
+    time: format(dateTime, 'h:ss aaa'),
+  };
+};


### PR DESCRIPTION
This PR adds the followings:

- NextUI table to display the League Game Schedule data
- Updates the seed sample data to make it easier to bypass a foreignKey error I was experiencing (may not be an issue for everyone)
- Adds the Games/Teams data to the getLeague API response
- Adds some rough typing to my data, as well as some basic utility functions

<img width="1415" alt="Screen Shot 2023-06-08 at 11 47 38 PM" src="https://github.com/masiddee/nextjs-soccer-manager/assets/5460663/41bebd63-4a4f-45d6-9480-6f96e3d33af5">
